### PR TITLE
Fixed TLS config key

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -64,7 +64,7 @@ class Config implements ConfigInterface
                 ConfigInterface::CONFIG_KEY_AUTH,
                 ConfigInterface::DEFAULT_AUTH
             ),
-            'tls' => $this->deploymentConfig->get(
+            'ssl' => $this->deploymentConfig->get(
                 ConfigInterface::CONFIG_KEY_TLS,
                 ConfigInterface::DEFAULT_TLS
             ),


### PR DESCRIPTION
\Zend_Mail_Protocol_Smtp uses the configuration key "ssl" instead of "tls"